### PR TITLE
various smaller fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+import io
 from distutils.spawn import find_executable
 import os
 import tempfile
@@ -42,14 +43,14 @@ def edit(text):
     editor = get_editor()
     filename = tempfile.mktemp(suffix=".html")
 
-    with open(filename, "wt") as file:
+    with io.open(filename, 'w', encoding='utf-8') as file:
         file.write(text)
 
     cmd_list = editor.split() + [filename]
     proc = subprocess.Popen(cmd_list, close_fds=True)
     proc.communicate()
 
-    with open(filename, "rt") as file:
+    with io.open(filename, 'r', encoding='utf-8') as file:
         return file.read()
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -59,7 +59,8 @@ def edit_with_external_editor(self, field):
     try:
         text = edit(text)
         self.note.fields[field] = text
-        self.note.flush()
+        if not self.addMode:
+            self.note.flush()
         self.loadNote(focusTo=field)
     except RuntimeError:
         return BUILTIN_EDITOR(self, field)

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 from distutils.spawn import find_executable
+import os
 import tempfile
 import subprocess
 import sys
@@ -12,6 +13,8 @@ BUILTIN_EDITOR = aqt.editor.Editor._onHtmlEdit
 def get_editor():
     config = mw.addonManager.getConfig(__name__)
     user_choice = config.get("editor")
+    if os.path.isfile(user_choice) and os.access(user_choice, os.X_OK):
+        return user_choice
     editors = [
         user_choice,
         user_choice + ".exe",


### PR DESCRIPTION
I forked the add-on from ankiweb. Thanks for sharing this great add-on. My version is [here](https://ankiweb.net/shared/info/1184418999).

Could you add a license file to this github repo? I could only use your ankiweb listing which according to the ankiweb terms is licensed as AGPL.

&nbsp;

Here are some changes from my version. I only did a very brief test with this version because I regularly use my extended version. For details see the commit messages. The AssertionError occurs since around 2.1.26 with new notes.

&nbsp;

Also: In windows `find_executable` didn't help with the vscode helper file "code.cmd" whereas the similar `shutil.which` found it. `find_executable` meant that instead of my user setting "code" the regular notepad.exe was used. Since I don't know anything about the details of these commands I didn't commit a change. Here's the repl output from my general python install in Windows10:


    >>> from distutils.spawn import find_executable

    >>> find_executable("code")

    >>> import shutil

    >>> shutil.which("code")
    'C:\\Program Files\\Microsoft VS Code\\bin\\code.CMD'


